### PR TITLE
Multi-stage build を使って、イメージサイズを小さくした

### DIFF
--- a/04/Dockerfile
+++ b/04/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN go build -o main main.go
+
+
+FROM alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/main .
+
+CMD [ "./main" ]

--- a/04/main.go
+++ b/04/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}


### PR DESCRIPTION
## なぜやるか
イメージサイズを小さくするため
## なにをやったのか
Docker の Multi-stage build を使って、Go 言語で開発したプロダクトのイメージサイズを小さくする
## 動作確認の手順
1. 04ディレクトリで下記のコマンドを実行
``` bash=
docker build -t go-hello .  
```
2. 実行
``` bash=
docker run go-hello
```